### PR TITLE
added check is thumb really created before saving it to DB

### DIFF
--- a/src/Jobs/GenerateThumbsJob.php
+++ b/src/Jobs/GenerateThumbsJob.php
@@ -104,7 +104,11 @@ class GenerateThumbsJob extends BasicVideoJob
             $img      = $this->tmpPath . $name;
             $interval = $i * $perSecond;
 
-            $this->encodingLib->saveFrame($this->videoService->getVideoTmpPathWithFilename($this->videoID), $img, $interval);
+            $frameCreated = $this->encodingLib->saveFrame($this->videoService->getVideoTmpPathWithFilename($this->videoID), $img, $interval);
+
+            // If thumb is not created do not store it in DB
+            if(!$frameCreated)
+                continue;
 
             $thumbRepo->create([
                 Config::get('thumb@video_id') => $this->videoID,

--- a/src/Libs/EncodingLib.php
+++ b/src/Libs/EncodingLib.php
@@ -50,6 +50,7 @@ class EncodingLib implements IEncodingLib
     public function saveFrame($src, $dst, $time)
     {
         $this->getVideo($src)->frame( \FFMpeg\Coordinate\TimeCode::fromSeconds($time) )->save($dst);
+        return file_exists($dst);
     }
 
     public function encode($src, $dst, $w, $h, $b, $progressFunc)


### PR DESCRIPTION
In case that movie is one minute long, and frame is taken every 10 second, I experienced cases where library wont save thumb on 60th second. Added check is thumb realy created, and if not, do not save thumb in database.